### PR TITLE
Update bower.json to fix archieml dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "1.2.0",
   "main": "dist/jquery.doctop.js",
   "dependencies": {
-    "archieml-js": "newsdev/archieml-js#0.1.1"
+    "archieml-js": "newsdev/archieml-js#0.3.1"
   },
   "devDependencies": {
     "jquery": "~1.11.1",


### PR DESCRIPTION
This stumped me for an hour:

Using the current version of doctop and the provided archieml.js dependency (0.1.1), arrays were not being returned properly, e.g.:
https://jsfiddle.net/phillipadsmith/nzxhvpjn/

However, updating to archieml.js 0.3.1 returned the expected results:
http://jsfiddle.net/phillipadsmith/ov16Leoh/

Given that archieml is a dependency for using the ArchieML parsing, I would propose updating the dependency! :)

Hope this helps.